### PR TITLE
Remove color match checkbox

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -21,7 +21,6 @@ export const ID_CUSTOM_ICON_URL = `${EXTENSION_NAME}-custom-icon-url`;
 export const ID_CUSTOM_ICON_SIZE_INPUT = `${EXTENSION_NAME}-custom-icon-size`;
 export const ID_FA_ICON_CODE_INPUT = `${EXTENSION_NAME}-fa-icon-code`;
 // --- 结束新增 ---
-export const ID_COLOR_MATCH_CHECKBOX = `${EXTENSION_NAME}-color-match`;
 
 // --- 新增功能相关ID ---
 export const ID_GLOBAL_ICON_SIZE_INPUT = `${EXTENSION_NAME}-global-icon-size`;

--- a/events.js
+++ b/events.js
@@ -474,7 +474,6 @@ export function setupEventListeners() {
     safeAddListener(Constants.ID_CUSTOM_ICON_URL, 'input', handleSettingsChange);
     safeAddListener(Constants.ID_CUSTOM_ICON_SIZE_INPUT, 'input', handleSettingsChange);
     safeAddListener(Constants.ID_FA_ICON_CODE_INPUT, 'input', handleSettingsChange);
-    safeAddListener(Constants.ID_COLOR_MATCH_CHECKBOX, 'change', handleSettingsChange);
 
     // File upload listener is set up in settings.js -> setupSettingsEventListeners
 

--- a/index.js
+++ b/index.js
@@ -89,7 +89,6 @@ function initializePlugin() {
         sharedState.domElements.customIconUrl = document.getElementById(Constants.ID_CUSTOM_ICON_URL);
         sharedState.domElements.customIconSizeInput = document.getElementById(Constants.ID_CUSTOM_ICON_SIZE_INPUT);
         sharedState.domElements.faIconCodeInput = document.getElementById(Constants.ID_FA_ICON_CODE_INPUT);
-        sharedState.domElements.colorMatchCheckbox = document.getElementById(Constants.ID_COLOR_MATCH_CHECKBOX);
 
         window.quickReplyMenu = {
             handleQuickReplyClick,

--- a/settings.js
+++ b/settings.js
@@ -18,7 +18,6 @@ export function updateIconDisplay() {
     const customIconSizeSetting = settings.customIconSize || Constants.DEFAULT_CUSTOM_ICON_SIZE; // 自定义图标大小
     const globalIconSizeSetting = settings.globalIconSize; // 全局图标大小 (可能为 null)
     const faIconCode = settings.faIconCode || '';
-    // const matchColors = settings.matchButtonColors !== false; // <--- 移除
 
     // 1. 清除按钮现有内容和样式
     button.innerHTML = '';
@@ -262,7 +261,6 @@ export function createSettingsHtml() {
                         <li>图标的大小和颜色将尽量匹配按钮的样式。</li>
                     </ul>
                 </li>
-                <li>可以勾选"使用与发送按钮相匹配的颜色风格"，让图标颜色自动适配发送按钮的类别（但也有可能匹配不上o(╥﹏╥)o）。</li>
             </ul>
 
 <p><strong>然后，你可以通过点击"菜单样式"按钮，来自定义快速回复菜单的外观：</strong></p>
@@ -516,6 +514,22 @@ export function handleSettingsChange(event) {
             settings.globalIconSize = null; // 如果为空或无效，则设为null以使用默认大小
         } else {
             settings.globalIconSize = parseFloat(sizeVal);
+        }
+    }
+
+    // 如果自定义图标URL或大小被手动修改，检查是否仍与已保存图标匹配
+    if (targetId === Constants.ID_CUSTOM_ICON_URL || targetId === Constants.ID_CUSTOM_ICON_SIZE_INPUT) {
+        const currentUrl = settings.customIconUrl;
+        const currentSize = settings.customIconSize;
+        const isStillSaved = settings.savedCustomIcons && settings.savedCustomIcons.some(
+            icon => icon.url === currentUrl && icon.size === currentSize
+        );
+        if (!isStillSaved) {
+            sharedState.currentSelectedSavedIconId = null;
+            const deleteBtn = document.getElementById(Constants.ID_DELETE_SAVED_ICON_BUTTON);
+            if (deleteBtn) deleteBtn.style.display = 'none';
+            const selectElement = document.getElementById(Constants.ID_CUSTOM_ICON_SELECT);
+            if (selectElement) selectElement.value = "";
         }
     }
 
@@ -988,23 +1002,21 @@ function handleDeleteSavedIcon() {
         return;
     }
 
+    const deletedIcon = settings.savedCustomIcons.find(icon => icon.id === currentId);
     settings.savedCustomIcons = settings.savedCustomIcons.filter(icon => icon.id !== currentId);
     sharedState.currentSelectedSavedIconId = null; // 清除当前选中
 
-    // 清空自定义图标设置区域的当前值 (如果被删除的是当前应用的)
     const customIconUrlInput = document.getElementById(Constants.ID_CUSTOM_ICON_URL);
     const customIconSizeInput = document.getElementById(Constants.ID_CUSTOM_ICON_SIZE_INPUT);
-    const iconTypeDropdown = document.getElementById(Constants.ID_ICON_TYPE_DROPDOWN);
 
-    // 检查当前应用的图标是否就是刚被删除的
-    if (customIconUrlInput.value && settings.savedCustomIcons.every(icon => icon.url !== customIconUrlInput.value)) { // 如果当前URL不在任何保存的图标中
-        customIconUrlInput.value = '';
-        if (customIconUrlInput.dataset.fullValue) delete customIconUrlInput.dataset.fullValue;
-        customIconSizeInput.value = Constants.DEFAULT_CUSTOM_ICON_SIZE;
-        // settings.customIconUrl = ''; // 也更新内存中的settings
-        // settings.customIconSize = Constants.DEFAULT_CUSTOM_ICON_SIZE;
-        // iconTypeDropdown.value = Constants.ICON_TYPES.ROCKET;
-        // settings.iconType = Constants.ICON_TYPES.ROCKET;
+    if (deletedIcon && customIconUrlInput && customIconSizeInput) {
+        const currentUrl = customIconUrlInput.dataset.fullValue || customIconUrlInput.value;
+        const currentSize = parseInt(customIconSizeInput.value, 10) || Constants.DEFAULT_CUSTOM_ICON_SIZE;
+        if (currentUrl === deletedIcon.url && currentSize === deletedIcon.size) {
+            customIconUrlInput.value = '';
+            if (customIconUrlInput.dataset.fullValue) delete customIconUrlInput.dataset.fullValue;
+            customIconSizeInput.value = Constants.DEFAULT_CUSTOM_ICON_SIZE;
+        }
     }
 
     updateCustomIconSelect(); // 刷新下拉列表

--- a/style.css
+++ b/style.css
@@ -83,20 +83,6 @@ body.qra-disabled #quick-reply-rocket-button {
     max-width: 120px !important;
 }
 
-/* 复选框和标签对齐 */
-.quick-reply-settings-row:has(#quick-reply-menu-color-match-checkbox) { /* 注意 ID 可能根据 constants.js 变化 */
-    display: flex;
-    align-items: center;
-}
-.quick-reply-settings-row:has(#quick-reply-menu-color-match-checkbox) label {
-    min-width: 0;
-    margin: 0;
-    text-align: left; /* 恢复左对齐 */
-}
-#quick-reply-menu-color-match-checkbox { /* 注意 ID 可能根据 constants.js 变化 */
-    margin-right: 5px;
-    vertical-align: middle;
-}
 
 /* --- 自定义图标和 Font Awesome 输入容器 --- */
 .custom-icon-container,


### PR DESCRIPTION
## Summary
- remove obsolete color-match checkbox constants and listeners
- clean CSS related to the removed checkbox
- update usage text
- reset selected icon state when editing custom icon inputs
- improve deletion logic for saved icons

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683d169cc9548320acd82e18d421402e
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the obsolete color match checkbox and cleaned up related code, styles, and usage text. Improved custom icon input handling and icon deletion logic.

- **Refactors**
  - Deleted color match checkbox constants, listeners, and CSS.
  - Updated icon selection to reset state when editing inputs.
  - Improved logic for deleting saved icons.

<!-- End of auto-generated description by cubic. -->

