### PR TITLE
Remove color match checkbox

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -21,7 +21,6 @@ export const ID_CUSTOM_ICON_URL = `${EXTENSION_NAME}-custom-icon-url`;
 export const ID_CUSTOM_ICON_SIZE_INPUT = `${EXTENSION_NAME}-custom-icon-size`;
 export const ID_FA_ICON_CODE_INPUT = `${EXTENSION_NAME}-fa-icon-code`;
 // --- 结束新增 ---
-export const ID_COLOR_MATCH_CHECKBOX = `${EXTENSION_NAME}-color-match`;
 
 // --- 新增功能相关ID ---
 export const ID_GLOBAL_ICON_SIZE_INPUT = `${EXTENSION_NAME}-global-icon-size`;

--- a/events.js
+++ b/events.js
@@ -474,7 +474,6 @@ export function setupEventListeners() {
     safeAddListener(Constants.ID_CUSTOM_ICON_URL, 'input', handleSettingsChange);
     safeAddListener(Constants.ID_CUSTOM_ICON_SIZE_INPUT, 'input', handleSettingsChange);
     safeAddListener(Constants.ID_FA_ICON_CODE_INPUT, 'input', handleSettingsChange);
-    safeAddListener(Constants.ID_COLOR_MATCH_CHECKBOX, 'change', handleSettingsChange);
 
     // File upload listener is set up in settings.js -> setupSettingsEventListeners
 

--- a/index.js
+++ b/index.js
@@ -89,7 +89,6 @@ function initializePlugin() {
         sharedState.domElements.customIconUrl = document.getElementById(Constants.ID_CUSTOM_ICON_URL);
         sharedState.domElements.customIconSizeInput = document.getElementById(Constants.ID_CUSTOM_ICON_SIZE_INPUT);
         sharedState.domElements.faIconCodeInput = document.getElementById(Constants.ID_FA_ICON_CODE_INPUT);
-        sharedState.domElements.colorMatchCheckbox = document.getElementById(Constants.ID_COLOR_MATCH_CHECKBOX);
 
         window.quickReplyMenu = {
             handleQuickReplyClick,

--- a/style.css
+++ b/style.css
@@ -83,20 +83,6 @@ body.qra-disabled #quick-reply-rocket-button {
     max-width: 120px !important;
 }
 
-/* 复选框和标签对齐 */
-.quick-reply-settings-row:has(#quick-reply-menu-color-match-checkbox) { /* 注意 ID 可能根据 constants.js 变化 */
-    display: flex;
-    align-items: center;
-}
-.quick-reply-settings-row:has(#quick-reply-menu-color-match-checkbox) label {
-    min-width: 0;
-    margin: 0;
-    text-align: left; /* 恢复左对齐 */
-}
-#quick-reply-menu-color-match-checkbox { /* 注意 ID 可能根据 constants.js 变化 */
-    margin-right: 5px;
-    vertical-align: middle;
-}
 
 /* --- 自定义图标和 Font Awesome 输入容器 --- */
 .custom-icon-container,


### PR DESCRIPTION
## Summary
- remove obsolete color-match checkbox constants and listeners
- clean CSS related to the removed checkbox
- update usage text
- reset selected icon state when editing custom icon inputs
- improve deletion logic for saved icons
- clarify that color matching is always enabled

## Testing
- `npm test` *(fails: Could not find package.json)*


------
https://chatgpt.com/codex/tasks/task_b_683d169cc9548320acd82e18d421402e
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the obsolete color match checkbox and related code. Color matching for icons is now always enabled by default.

- **Cleanup**
  - Deleted unused constants, event listeners, and CSS for the checkbox.
  - Updated help text to clarify color matching is always on.
  - Improved icon deletion and input reset logic.

<!-- End of auto-generated description by cubic. -->

